### PR TITLE
Removed splash screen and have a single page for settings

### DIFF
--- a/admin/timetable-admin.php
+++ b/admin/timetable-admin.php
@@ -15,7 +15,6 @@
  * @since 1.0.0
  */
 function timetable_add_caps() {
-
     $role = get_role('administrator');
     $role->add_cap('timetable_config');
 
@@ -24,28 +23,6 @@ function timetable_add_caps() {
 }
 
 add_action( 'admin_init', 'timetable_add_caps' );
-
-
-
-/**
- * Add a sub menu page underneath the existing Timetable Plugins Page
- *
- * @since 1.0.0
- */
-function timetable_options_page() {
-
-    add_submenu_page(
-        'timetable-plugin',        // $parent_slug
-        'Timetable Plugin',           // $page_title
-        timetable_options_title(), // $menu_title
-        'timetable_config',        // $capability
-        'timetable_options',       // $menu_slug
-        'timetable_options_html'        // $callback
-    );
-
-}
-
-add_action( 'admin_menu', 'timetable_options_page' );
 
 
 /**
@@ -127,11 +104,8 @@ function timetable_textarea_field_times_render() {
 }
 
 
-
 function timetable_settings_section_callback() {
     echo __( 'Enter your timetable details here.', 'timetable_widget_domain' );
 }
 
-
 ?>
-

--- a/admin/timetable-splash.php
+++ b/admin/timetable-splash.php
@@ -1,4 +1,0 @@
-<section id="introduction" class="wrap about-description">
-  <h1>Timetable</h1>
-  <p>Welcome, please configure the timetable in Settings.</p>
-</section>

--- a/timetable-foundation.php
+++ b/timetable-foundation.php
@@ -40,7 +40,7 @@ add_action('admin_init', 'timetable_plugin_add_caps');
 
 /**
  * Check to make sure that another plugin has not already registered the plugin
- * splash page. If it does not exist, add a top level Page into the WordPress admin
+ * options page. If it does not exist, add a top level Page into the WordPress admin
  * sidebar
  *
  * @var $page_title  string  This is the heading for the page.
@@ -61,7 +61,7 @@ if ( empty( $GLOBALS['admin_page_hooks']['timetable-plugin'] ) ) {
                 'Timetable',            // $menu_title
                 'timetable_plugin',     // $capability
                 'timetable-plugin',     // $menu_slug
-                'timetable_splash',     // $callback
+                'timetable_options',     // $callback
                 'dashicons-timetable',  // $icon
                 '10'                    // $position
             );
@@ -77,8 +77,8 @@ if ( empty( $GLOBALS['admin_page_hooks']['timetable-plugin'] ) ) {
  *
  * @since 1.0.0
  */
-function timetable_splash() {
-    require_once( plugin_dir_path( __FILE__ ) . 'admin/' . 'timetable-splash.php' );
+function timetable_options() {
+    require_once( plugin_dir_path( __FILE__ ) . 'admin/' . 'timetable-options.php' );
 }
 
 

--- a/timetable.php
+++ b/timetable.php
@@ -63,7 +63,7 @@ function timetable_description() {
  * @return string
  */
 function timetable_options_title() {
-    return __("Settings");
+    return __("Timetable Settings");
 }
 
 


### PR DESCRIPTION
- Removed `timetable-splash` and directed initial start screen to `timetable-options`
- Removed submenu for `Settings`